### PR TITLE
Add slashes in JSON string output

### DIFF
--- a/src/Controller/DumpTranslationsController.php
+++ b/src/Controller/DumpTranslationsController.php
@@ -24,10 +24,12 @@ class DumpTranslationsController extends AbstractController
     {
         $isDebug = $parameters->get("kernel.debug");
         $catalogue = $extractor->fetchCatalogue($namespace, $locale, !$isDebug);
+        // we are embedding it inside a string, so we must double escape backslashes
+        $json = \addslashes($catalogue->getCatalogueJson());
 
         $response = new JsonResponse(
             // use JSON parse and a string here, as it is way faster than parsing JavaScript in the browser.
-            "JSON.parse('{$catalogue->getCatalogueJson()}')",
+            "JSON.parse('{$json}')",
             200,
             [
                 // prevent magic byte insertion


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | yes                                                               |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | —

<!-- describe your changes below -->
As we are embedding the JSON inside a JS string, we need to double escape the escapes.