### PR TITLE
Use ConfigCache instead of symfony/cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.4
+=====
+
+*   (improvement) Use `ConfigCache` instead of `symfony/cache`.
+
+
 1.0.3
 =====
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "symfony/cache-contracts": "^1.1 || ^2.0",
         "symfony/config": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",
         "symfony/framework-bundle": "^4.3 || ^5.0",

--- a/src/Controller/DumpTranslationsController.php
+++ b/src/Controller/DumpTranslationsController.php
@@ -21,7 +21,7 @@ class DumpTranslationsController extends AbstractController
     ) : Response
     {
         $isDebug = $parameters->get("kernel.debug");
-        $catalogue = $extractor->fetchCatalogue($namespace, $locale, !$isDebug);
+        $catalogue = $extractor->fetchCatalogue($namespace, $locale);
 
         $response = new Response(
             \sprintf(

--- a/src/Extractor/TranslationsExtractor.php
+++ b/src/Extractor/TranslationsExtractor.php
@@ -185,8 +185,6 @@ class TranslationsExtractor
 
 
     /**
-     * @param string $locale
-     *
      * @return ResourceInterface[]
      */
     private function getTrackedResources (string $locale) : array

--- a/src/Extractor/TranslationsExtractor.php
+++ b/src/Extractor/TranslationsExtractor.php
@@ -15,33 +15,19 @@ class TranslationsExtractor
 {
     private const CACHE_PREFIX = "becklyn_translations.catalogue.%s.%s";
 
-
-    /**
-     * @var CacheInterface
-     */
+    /** @var CacheInterface */
     private $cache;
 
-    /**
-     * @var TranslatorInterface
-     */
+    /** @var TranslatorInterface */
     private $translator;
 
-
-    /**
-     * @var CacheDigestGenerator
-     */
+    /** @var CacheDigestGenerator */
     private $cacheDigestGenerator;
 
-
-    /**
-     * @var KeyCatalogue
-     */
+    /** @var KeyCatalogue */
     private $catalogue;
 
-
-    /**
-     * @var TranslationsCompiler
-     */
+    /** @var TranslationsCompiler */
     private $translationsCompiler;
 
 

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -2,10 +2,11 @@ services:
     _defaults:
         autoconfigure: true
         autowire: true
+        bind:
+            $projectDir: '%kernel.project_dir%'
+            $cacheDir: '%kernel.cache_dir%'
+            $isDebug: '%kernel.debug%'
 
     Becklyn\Translations\:
         resource: '../../*'
         exclude: '../../{Resources,BecklynTranslationsBundle.php}'
-
-    Becklyn\Translations\Extractor\TranslationsCompiler:
-        $projectDir: '%kernel.project_dir%'

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -10,3 +10,9 @@ services:
     Becklyn\Translations\:
         resource: '../../*'
         exclude: '../../{Resources,BecklynTranslationsBundle.php}'
+
+    Becklyn\Translations\Extractor\TranslationsExtractor:
+        calls:
+            - method: setConfigCacheFactory
+              arguments:
+                  - '@config_cache_factory'

--- a/vendor-bin/test/composer.json
+++ b/vendor-bin/test/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "becklyn/php-cs": "^3.0"
+        "becklyn/php-cs": "^3.0.12"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | — <!-- insert URL here -->                                  |

<!-- describe your changes below -->
The as with the JS router bundle, this one uses the `ConfigCache` instead of just using the `symfony/cache`.

This has the explicit improvement, that we add a new case, which normally heavily improves performance. The four possible cases are:

* symfony mode `debug`, cache empty (normal debug)
* symfony mode `debug`, cache filled (was not possible previously, as we never used the cache in `debug`)
* symfony mode `prod`, cache empty (not interesting, as practically never happens. Should stay as-is though)
* symfony mode `prod`, cache filled (normal prod)

Here is the comparison:

|  | dev (cache empty) | dev (cache filled) | prod (cache filled) |
| --- | ---- | ---- | --- |
| before | `680ms` | (`680ms`) \* | `0.2ms` |
| after | `690ms` | `8ms` | `0.04ms` |

\*) no special case, as we never used the cache in debug, so the "cache was always empty"